### PR TITLE
Group traversed commits by tag

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/CCLog.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/CCLog.xcscheme
@@ -76,6 +76,34 @@
                ReferencedContainer = "container:">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SemanticVersioning"
+               BuildableName = "SemanticVersioning"
+               BlueprintName = "SemanticVersioning"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SemanticVersioningTests"
+               BuildableName = "SemanticVersioningTests"
+               BlueprintName = "SemanticVersioningTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -111,6 +139,16 @@
                BlueprintIdentifier = "ConventionalCommitsTests"
                BuildableName = "ConventionalCommitsTests"
                BlueprintName = "ConventionalCommitsTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "SemanticVersioningTests"
+               BuildableName = "SemanticVersioningTests"
+               BlueprintName = "SemanticVersioningTests"
                ReferencedContainer = "container:">
             </BuildableReference>
          </TestableReference>

--- a/Package.swift
+++ b/Package.swift
@@ -25,10 +25,16 @@ let package = Package(
         ),
         .target(name: "CCLogCore",
                 dependencies: [ "ConventionalCommits",
+                                "SemanticVersioning",
                                 "SwiftGit2",
                                 .product(name: "ArgumentParser", package: "swift-argument-parser")
                 ],
                 path: "Targets/CCLogCore/Sources"
+        ),
+        .target(
+            name: "SemanticVersioning",
+            dependencies: ["ParserCombinator"],
+            path: "Targets/SemanticVersioning/Sources"
         ),
         .target(
             name: "ConventionalCommits",
@@ -53,6 +59,11 @@ let package = Package(
             name: "ConventionalCommitsTests",
             dependencies: ["ConventionalCommits"],
             path: "Targets/ConventionalCommits/Tests"
+        ),
+        .testTarget(
+            name: "SemanticVersioningTests",
+            dependencies: ["SemanticVersioning"],
+            path: "Targets/SemanticVersioning/Tests"
         ),
         
     ]

--- a/Targets/CCLog/Sources/CCLog.swift
+++ b/Targets/CCLog/Sources/CCLog.swift
@@ -61,7 +61,7 @@ A Swift command-line tool to generate change log files for conventional commits
         print(tagQuery)
         
         switch CCLogCore.generateGitLog(
-            tagQuery: "test-tag",
+            tagQuery: "1.0.0..test-tag",
             from: URL(string: "/Users/alexanderweiss/Documents/Programming/swift-projects/LoggingKit")!) {
         case .success:
             throw ExitCode.success

--- a/Targets/CCLog/Sources/CCLog.swift
+++ b/Targets/CCLog/Sources/CCLog.swift
@@ -56,8 +56,9 @@ A Swift command-line tool to generate change log files for conventional commits
     public func run() throws {
         
         switch CCLogCore.generateGitLog(
-            tagQuery: "1.0.0",
-            from: URL(string: "/Users/alexanderweiss/Documents/Programming/swift-projects/LoggingKit")!) {
+            tagQuery: "1.0.0..v2.0.0",
+            from: URL(string: "/Users/alexanderweiss/Documents/Programming/swift-projects/LoggingKit")!
+        ) {
         case .success:
             throw ExitCode.success
         case let .failure(error):

--- a/Targets/CCLog/Sources/CCLog.swift
+++ b/Targets/CCLog/Sources/CCLog.swift
@@ -55,13 +55,8 @@ A Swift command-line tool to generate change log files for conventional commits
     // MARK: - Run
     public func run() throws {
         
-        
-        print(path)
-        print(tagFilter)
-        print(tagQuery)
-        
         switch CCLogCore.generateGitLog(
-            tagQuery: "1.0.0..test-tag",
+            tagQuery: "1.0.0",
             from: URL(string: "/Users/alexanderweiss/Documents/Programming/swift-projects/LoggingKit")!) {
         case .success:
             throw ExitCode.success

--- a/Targets/CCLogCore/Sources/CCLogCore.swift
+++ b/Targets/CCLogCore/Sources/CCLogCore.swift
@@ -24,9 +24,11 @@ public enum CCLogCore {
             return .failure(.failedToOpenRepository)
         }
         
+        //TODO: Improve performance. Here we go traverse the repository twice. Once for the commits
+        //and once for the tags
         guard case let .success(commits) = repository.traverseCommits(from: tagQuery),
               case let .success(tags) = repository.traverseTags(from: tagQuery) else {
-            return .failure(.failedToQueryTags)
+            return .failure(.failedToCollectCommits)
         }
         
         let changelog = ChangeLog(commits: commits, tags: tags)

--- a/Targets/CCLogCore/Sources/CCLogCore.swift
+++ b/Targets/CCLogCore/Sources/CCLogCore.swift
@@ -11,6 +11,8 @@ import SwiftGit2
 import Clibgit2
 
 
+
+
 public enum CCLogCore {
     public static func generateGitLog(
         tagQuery: String,
@@ -25,8 +27,15 @@ public enum CCLogCore {
         switch Repository.at(repository) {
         case let .success(repo):
             
-            let commits = repo.traverseCommits(from: tagQuery)
-            print(commits)
+            guard case let .success(commits) = repo.traverseCommits(from: tagQuery) else {
+                return .failure(.failedToQueryTags)
+            }
+            
+            let ccommits = commits.map { ConventionalCommit(data: $0.message)}
+            ccommits.forEach {
+                print($0?.type)
+            }
+            
             break;
         case let .failure(error):
             return .failure(.gitError(error: GitError(from: error)))

--- a/Targets/CCLogCore/Sources/Changelog/ChangeSet.swift
+++ b/Targets/CCLogCore/Sources/Changelog/ChangeSet.swift
@@ -1,0 +1,72 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Weiß on 21.11.20.
+//
+
+import Foundation
+import ConventionalCommits
+import SwiftGit2
+
+
+// MARK: - Changeset
+
+/// A changeset represents a group of changes
+struct ChangeSet {
+    let changes: [Change]
+    
+    init(from commits: [Commit]) {
+        self.changes = commits.map { .init(commit: $0)}
+    }
+}
+
+// MARK: - Change
+
+/// A change represents one change in the repository.
+///
+/// In this context a change is always tied to a git commit. If the commit message
+/// conforms to the conventional commit specification this information is extracted.
+struct Change {
+    let commit: Commit
+    let conventionalCommit: ConventionalCommit?
+    
+    init(commit: Commit) {
+        self.commit = commit
+        self.conventionalCommit = ConventionalCommit(data: commit.message)
+    }
+}
+
+// MARK: Change + Conventional Commit
+extension Change {
+    var type: String? {
+        return conventionalCommit?.type
+    }
+    
+    var scope: String? {
+        return conventionalCommit?.scope
+    }
+    
+    var description: String? {
+        return conventionalCommit?.description
+    }
+    
+    var body: String? {
+        return conventionalCommit?.body
+    }
+    
+    var isBreaking: Bool {
+        return conventionalCommit?.isBreaking ?? false
+    }
+    
+    var contributor: Contributor {
+        return Contributor(name: commit.author.name, email: commit.author.email)
+    }
+    
+    struct Contributor {
+        let name: String
+        let email: String
+    }
+}
+
+

--- a/Targets/CCLogCore/Sources/Changelog/Changelog.swift
+++ b/Targets/CCLogCore/Sources/Changelog/Changelog.swift
@@ -39,7 +39,11 @@ extension ChangeLog {
             
             let remaining = commits[endIndex...]
             commits = Array(remaining)
-            let release = Release(version: Version(value: tagReference.name), tag: tagReference, changeSet: ChangeSet(from: foundCommits))
+            
+            
+            var tagName = tagReference.name.deletingPrefix("v")
+            
+            let release = Release(version: Version(value: tagName), tag: tagReference, changeSet: ChangeSet(from: foundCommits))
             foundReleases.append(release)
         }
             
@@ -48,3 +52,9 @@ extension ChangeLog {
     }
 }
 
+extension String {
+    fileprivate func deletingPrefix(_ prefix: String) -> String {
+        guard self.hasPrefix(prefix) else { return self }
+        return String(self.dropFirst(prefix.count))
+    }
+}

--- a/Targets/CCLogCore/Sources/Changelog/Changelog.swift
+++ b/Targets/CCLogCore/Sources/Changelog/Changelog.swift
@@ -1,0 +1,50 @@
+//
+//  Changelog.swift
+//  
+//
+//  Created by Alexander Weiß on 21.11.20.
+//
+
+import Foundation
+import ConventionalCommits
+import SwiftGit2
+
+
+public struct ChangeLog {
+    let releases: [Release]?
+    let unreleased: ChangeSet?
+}
+
+extension ChangeLog {
+        
+    init(commits: [Commit], tags: [TagReference]) {
+        
+        var commits: [Commit] = commits.reversed()
+        let tags: [TagReference] = tags.reversed()
+        
+        
+        var foundReleases: [Release] = []
+        
+        tags.forEach { tagReference in
+            
+            print("Remaining commit size: \(commits.count)")
+            print("Find tags for: \(tagReference)")
+           
+            let endIndex = commits.prefix(while: { $0.oid != tagReference.oid }).endIndex + 1
+            
+            
+            let foundCommits = Array(commits[..<endIndex])
+            
+            print("Found \(foundCommits.count) commits for tag")
+            
+            let remaining = commits[endIndex...]
+            commits = Array(remaining)
+            let release = Release(version: Version(value: tagReference.name), tag: tagReference, changeSet: ChangeSet(from: foundCommits))
+            foundReleases.append(release)
+        }
+            
+        releases = foundReleases.reversed()
+        unreleased  = ChangeSet(from: commits)
+    }
+}
+

--- a/Targets/CCLogCore/Sources/Changelog/Release.swift
+++ b/Targets/CCLogCore/Sources/Changelog/Release.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Weiß on 21.11.20.
+//
+
+import Foundation
+import SwiftGit2
+
+/// Represents a mapping from a git tag to a specific version
+/// and the corresponding changes made to the repository
+struct Release {
+    let version: Version
+    let tag: TagReference
+    let changeSet: ChangeSet
+}
+
+/// Represents a version
+struct Version {
+    let value: String
+}

--- a/Targets/CCLogCore/Sources/Changelog/Release.swift
+++ b/Targets/CCLogCore/Sources/Changelog/Release.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftGit2
+import SemanticVersioning
 
 /// Represents a mapping from a git tag to a specific version
 /// and the corresponding changes made to the repository
@@ -19,4 +20,10 @@ struct Release {
 /// Represents a version
 struct Version {
     let value: String
+    let semanticVersion: SemanticVersion?
+    
+    init(value: String) {
+        self.value = value
+        self.semanticVersion = SemanticVersion(data: value)
+    }
 }

--- a/Targets/CCLogCore/Sources/Errors.swift
+++ b/Targets/CCLogCore/Sources/Errors.swift
@@ -15,6 +15,7 @@ public enum CCLogError: Error {
     case tagQueryInvalid
     case failedToQueryTags
     case failedToOpenRepository
+    case failedToCollectCommits
 }
 
 // MARK: - GitError

--- a/Targets/CCLogCore/Sources/Errors.swift
+++ b/Targets/CCLogCore/Sources/Errors.swift
@@ -13,6 +13,7 @@ import Clibgit2
 public enum CCLogError: Error {
     case gitError(error: GitError)
     case tagQueryInvalid
+    case failedToQueryTags
 }
 
 // MARK: - GitError

--- a/Targets/CCLogCore/Sources/Errors.swift
+++ b/Targets/CCLogCore/Sources/Errors.swift
@@ -14,6 +14,7 @@ public enum CCLogError: Error {
     case gitError(error: GitError)
     case tagQueryInvalid
     case failedToQueryTags
+    case failedToOpenRepository
 }
 
 // MARK: - GitError

--- a/Targets/CCLogCore/Sources/Extensions/ConventionalCommit+String.swift
+++ b/Targets/CCLogCore/Sources/Extensions/ConventionalCommit+String.swift
@@ -1,0 +1,13 @@
+//
+//  ConventionalCommit+String.swift
+//  
+//
+//  Created by Alexander Weiß on 18.11.20.
+//
+
+import ConventionalCommits
+
+
+
+extension ConventionalCommit {
+}

--- a/Targets/CCLogCore/Sources/Extensions/Repository.swift
+++ b/Targets/CCLogCore/Sources/Extensions/Repository.swift
@@ -118,9 +118,22 @@ extension Repository {
         
         var oid: git_oid = git_oid()
         var revWalkError: Int32 = GIT_OK.rawValue
+        var lastTag: Tag?
+        
+        
+        
+        let alltags = self.allTags()
     
         while (revWalkError = git_revwalk_next(&oid, walker), revWalkError).1 == GIT_OK.rawValue {
-            let c = self.commit(OID(oid))
+            
+            let oidD = OID(oid)
+            
+            
+            
+           
+            let tag = self.tag(named: "test-tag")
+            let c = self.commit(oidD)
+            print(try! c.get().message)
             commits.append(try! c.get())
         }
         

--- a/Targets/CCLogCore/Sources/Extensions/Repository.swift
+++ b/Targets/CCLogCore/Sources/Extensions/Repository.swift
@@ -10,8 +10,14 @@ import SwiftGit2
 import Clibgit2
 
 extension Repository {
-    
-    func traverseCommits(from query: TagQuery) -> Result<[Commit], NSError> {
+
+    /// Calculate the start and end commit from a `TagQuery` instance
+    /// - Parameter query: Query used to calculate start and end
+    /// - Returns: Result containing the start and end commit of the query
+    private func findStartEnd(from query: TagQuery) -> Result<(Commit?, Commit), NSError> {
+        
+        var startCommitToReturn: Commit!
+        var endCommitToReturn: Commit!
         
         switch query {
         case let .closed(start, end):
@@ -25,8 +31,9 @@ extension Repository {
             else {
                 return .failure(NSError.init())
             }
+            startCommitToReturn = startCommit
+            endCommitToReturn = endCommit
             
-            return self.traverseCommits(from: startCommit, to: endCommit)
         case let .rightOpen(start):
             let startTag = self.tag(named: start)
             
@@ -39,7 +46,8 @@ extension Repository {
                 return .failure(NSError.init())
             }
             
-            return self.traverseCommits(from: startCommit, to: endCommit)
+            startCommitToReturn = startCommit
+            endCommitToReturn = endCommit
             
         case let .leftOpen(end):
             
@@ -53,7 +61,8 @@ extension Repository {
             else {
                 return .failure(NSError.init())
             }
-            return self.traverseCommits(from: startCommit, to: endCommit)
+            startCommitToReturn = startCommit
+            endCommitToReturn = endCommit
         
         case let .single(tag):
             let endTag = self.tag(named: tag)
@@ -65,9 +74,11 @@ extension Repository {
             }
             
             var startCommit: Commit?
-            
+
+            // Find the tag before the `tag`
+            // If there is no tag before `tag` means startCommit = nil and so we start from the beginning of the repository
             let indexOfStartTag = allTags.firstIndex(where: {$0 == tagRefEnd})
-            
+
             if let indexOfStartTag = indexOfStartTag {
                 let previousTagIndex = (indexOfStartTag + 1)
                 if previousTagIndex < allTags.count {
@@ -79,17 +90,77 @@ extension Repository {
                 }
             }
             
-            
-            return self.traverseCommits(from: startCommit, to: endCommit)
-            
-        default:
-            fatalError("Unimplemented")
+            startCommitToReturn = startCommit
+            endCommitToReturn = endCommit
         }
-        
-        return .success([])
+        return .success((startCommitToReturn, endCommitToReturn))
+    }
+    
+
+    func traverseCommits(from query: TagQuery) -> Result<[Commit], NSError> {
+        switch self.findStartEnd(from: query) {
+        case let .success((startCommit, endCommit)):
+            return self.traverseCommits(from: startCommit, to: endCommit)
+        case let .failure(error):
+            return .failure(error)
+        }
     }
     
     
+    func traverseTags(from query: TagQuery) -> Result<[TagReference], NSError> {
+        switch self.findStartEnd(from: query) {
+        case let .success((startCommit, endCommit)):
+            return  self.traverseTags(from: startCommit, to: endCommit)
+        case let .failure(error):
+            return .failure(error)
+        }
+    }
+    
+    
+    /// Traverse through commits from the `end` to `start` and collect every tag that references a commi on the way.
+    ///
+    /// This method uses git_revwalk to walk from `end` to `start`. If the start commit is nil this method will
+    /// traverse the complete history beginning from `end` -> so up to the initial commit of the repository.
+    ///
+    /// The tags are ordered from  descending according to the commit time.
+    ///
+    /// - Parameters:
+    ///   - start: The start commit
+    ///   - end: The end commit
+    ///   - startInclusive: Flag to include the start commit in traversal
+    /// - Returns: Result containing the requested commits or an error
+    private func traverseTags(from start: Commit?, to end: Commit, startInclusive: Bool = false) -> Result<[TagReference], NSError>  {
+        
+        let allTags = Dictionary(grouping: try! self.allTags().get()) { $0.oid }
+        var tagsToReturn: [TagReference] = []
+        
+        guard case let commits = try? self.traverseCommits(from: start, to: end, startInclusive: startInclusive).get() else {
+            return .failure(.init())
+        }
+        
+        commits?.forEach {
+            if let tag = allTags[$0.oid] {
+                
+                tag.first?.oid
+                tagsToReturn.append(tag.first!)
+            }
+        }
+        return .success(tagsToReturn)
+    }
+    
+    /// Traverse through and collect commits from the start to end commit.
+    ///
+    /// This method uses git_revwalk to walk from `end` to `start`. If the start commit is nil this method will
+    /// traverse the complete history beginning from `end` -> so up to the initial commit of the repository.
+    ///
+    /// The commits are ordered from `end` to `start`. This normally means the commits are order descending according
+    /// to the commit time.
+    ///
+    /// - Parameters:
+    ///   - start: The start commit
+    ///   - end: The end commit
+    ///   - startInclusive: Flag to include the start commit in traversal
+    /// - Returns: Result containing the requested commits or an error
     private func traverseCommits(from start: Commit?, to end: Commit, startInclusive: Bool = false) -> Result<[Commit], NSError> {
         
         // Function parameters
@@ -118,38 +189,22 @@ extension Repository {
         
         var oid: git_oid = git_oid()
         var revWalkError: Int32 = GIT_OK.rawValue
-        var lastTag: Tag?
         
-        
-        
-        let alltags = self.allTags()
-    
         while (revWalkError = git_revwalk_next(&oid, walker), revWalkError).1 == GIT_OK.rawValue {
-            
-            let oidD = OID(oid)
-            
-            
-            
-           
-            let tag = self.tag(named: "test-tag")
-            let c = self.commit(oidD)
-            print(try! c.get().message)
-            commits.append(try! c.get())
-        }
-        
-        if revWalkError != GIT_ITEROVER.rawValue {
-            return .failure(NSError(gitError: gitError, pointOfFailure: "git_revwalk_next"))
-        }
+           let c = self.commit(OID(oid))
+           commits.append(try! c.get())
+       }
+       
+       if revWalkError != GIT_ITEROVER.rawValue {
+           return .failure(NSError(gitError: gitError, pointOfFailure: "git_revwalk_next"))
+       }
 
-        if startInclusive && start != nil {
-            commits.append(start!)
-        }
+       if startInclusive && start != nil {
+           commits.append(start!)
+       }
         
         return .success(commits)
     }
-    
-    
-    
 }
 
 

--- a/Targets/CCLogCore/Sources/Protocols/Renderable.swift
+++ b/Targets/CCLogCore/Sources/Protocols/Renderable.swift
@@ -1,0 +1,13 @@
+//
+//  Renderable.swift
+//  
+//
+//  Created by Alexander Weiß on 21.11.20.
+//
+
+import Foundation
+
+
+protocol Renderable {
+    func render() -> Result<String, NSError>
+}

--- a/Targets/ParserCombinator/Sources/Streaming.swift
+++ b/Targets/ParserCombinator/Sources/Streaming.swift
@@ -1,0 +1,44 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Weiß on 23.11.20.
+//
+
+import Foundation
+
+extension Parser where Input: RangeReplaceableCollection {
+    
+    var stream: Parser<AnyIterator<Input>, [Output]> {
+        .init { stream in
+            var buffer = Input()
+            var outputs: [Output] = []
+            
+            while let chunk = stream.next() {
+                buffer.append(contentsOf: chunk)
+                while let output = self.run(&buffer) {
+                    outputs.append(output)
+                }
+            }
+            return outputs
+        }
+    }
+}
+
+
+extension Parser where Input: RangeReplaceableCollection {
+    
+    func run(
+        input: inout AnyIterator<Input>,
+        output streamOut: (Output) -> Void
+    ) {
+        var buffer = Input()
+        while let chunk = input.next() {
+            buffer.append(contentsOf: chunk)
+            while let output = self.run(&buffer) {
+                streamOut(output)
+            }
+        }
+    }
+    
+}

--- a/Targets/SemanticVersioning/Sources/SemanticVersion.swift
+++ b/Targets/SemanticVersioning/Sources/SemanticVersion.swift
@@ -1,0 +1,144 @@
+//
+//  SemanticVersion.swift
+//  
+//
+//  Created by Alexander Weiß on 21.11.20.
+//
+
+import Foundation
+import ParserCombinator
+
+// MARK: - SemanticVersion
+struct SemanticVersion {
+
+    let core: Core
+    let preReleaseIdentifiers: [String]
+    let buildIdentifiers: [String]
+    
+    public var major: Int {
+        return core.major
+    }
+    
+    public var minor: Int {
+        core.minor
+    }
+    
+    public var patch: Int {
+        core.patch
+    }
+}
+
+// MARK: - Parser
+extension SemanticVersion {
+    
+    private static let parser: Parser<Substring, SemanticVersion> = {
+        
+        let alphaNumericAndHypen = Parser<Substring, Substring>
+            .prefix(while: { $0.isLetter || $0.isNumber || $0 == "-" })
+        
+        // Pre-Release identifiers
+        let preReleaseIdentifier = alphaNumericAndHypen
+            .map(String.init)
+        
+        let preReleaseIdentifiersParser = Parser<Substring, Void>.skip("-")
+            .take(preReleaseIdentifier.zeroOrMore(separatedBy: "."))
+        
+        // Build identifiers
+        let buildIdentifier = alphaNumericAndHypen
+            .map(String.init)
+        
+        let buildIdentifierParser = Parser<Substring, Void>.skip("+")
+            .take(buildIdentifier.zeroOrMore(separatedBy: "."))
+        
+        return Core.parser
+            .take(.optional(preReleaseIdentifiersParser))
+            .take(.optional(buildIdentifierParser))
+            .map { core, preReleaseIdentifiers, buildIdentifierParser  in
+                return SemanticVersion(core: core,
+                                       preReleaseIdentifiers: preReleaseIdentifiers != nil ? preReleaseIdentifiers! : [],
+                                       buildIdentifiers:  buildIdentifierParser != nil ? buildIdentifierParser! : []
+                )
+            }
+    }()
+    
+    public init?(data: String) {
+        guard let match = SemanticVersion.parser.run(data[...]).match else {
+            return nil
+        }
+        
+        self = match
+    }
+    
+    internal init(major: Int, minor: Int, patch: Int, preReleaseIdentifiers: [String] = [], buildIdentifiers: [String] = []) {
+        self.core = Core(major: major, minor: minor, patch: patch)
+        self.preReleaseIdentifiers = preReleaseIdentifiers
+        self.buildIdentifiers = buildIdentifiers
+    }
+}
+
+//MARK: - Comparable
+extension SemanticVersion: Comparable {
+    static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        return !(lhs < rhs) && !(lhs > rhs)
+    }
+    
+    //Credit: https://github.com/glwithu06/Semver.swift/blob/master/Sources/Semver.swift
+    static func <(lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        
+        for (left, right) in zip([lhs.major, lhs.minor, lhs.patch],  [rhs.major, rhs.minor, rhs.patch]) where left != right {
+            return left < right
+        }
+        
+        // If both vesions are equal, preReleaseIdentifiers are needed to be checked
+        if lhs.preReleaseIdentifiers.count == 0 { return false }
+        if rhs.preReleaseIdentifiers.count == 0 { return true }
+        
+        for (l, r) in zip(lhs.preReleaseIdentifiers, rhs.preReleaseIdentifiers) {
+               switch (l.isNumber, r.isNumber) {
+               case (true, true):
+                   let result = l.compare(r, options: .numeric)
+                   if result == .orderedSame {
+                       continue
+                   }
+                   return result == .orderedAscending
+               case (true, false): return true
+               case (false, true): return false
+               default:
+                   if l == r {
+                       continue
+                   }
+                   return l < r
+               }
+           }
+
+        return lhs.preReleaseIdentifiers.count < rhs.preReleaseIdentifiers.count
+    }
+}
+
+
+// MARK: - Core
+extension SemanticVersion {
+    struct Core {
+        public let major: Int
+        public let minor: Int
+        public let patch: Int
+        
+        internal static let parser: Parser<Substring, Core> = {
+            return Parser<Substring, Int>.int
+                .skip(".")
+                .take(.int)
+                .skip(".")
+                .take(.int)
+                .map { major, minor, patch in
+                    return Core(major:major, minor: minor, patch: patch)
+                }
+        }()
+    }
+}
+
+// MARK: - Helpers
+extension String {
+    fileprivate var isNumber: Bool {
+        return !isEmpty && rangeOfCharacter(from: CharacterSet.decimalDigits.inverted) == nil
+    }
+}

--- a/Targets/SemanticVersioning/Sources/SemanticVersion.swift
+++ b/Targets/SemanticVersioning/Sources/SemanticVersion.swift
@@ -9,11 +9,11 @@ import Foundation
 import ParserCombinator
 
 // MARK: - SemanticVersion
-struct SemanticVersion {
+public struct SemanticVersion {
 
     let core: Core
-    let preReleaseIdentifiers: [String]
-    let buildIdentifiers: [String]
+    public let preReleaseIdentifiers: [String]
+    public let buildIdentifiers: [String]
     
     public var major: Int {
         return core.major
@@ -78,12 +78,12 @@ extension SemanticVersion {
 
 //MARK: - Comparable
 extension SemanticVersion: Comparable {
-    static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+    public static func == (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
         return !(lhs < rhs) && !(lhs > rhs)
     }
     
     //Credit: https://github.com/glwithu06/Semver.swift/blob/master/Sources/Semver.swift
-    static func <(lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+    public static func <(lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
         
         for (left, right) in zip([lhs.major, lhs.minor, lhs.patch],  [rhs.major, rhs.minor, rhs.patch]) where left != right {
             return left < right

--- a/Targets/SemanticVersioning/Tests/SemanticVersionComparableTests.swift
+++ b/Targets/SemanticVersioning/Tests/SemanticVersionComparableTests.swift
@@ -1,0 +1,77 @@
+//
+//  File.swift
+//  
+//
+//  Created by Alexander Weiß on 22.11.20.
+//
+
+import Foundation
+import XCTest
+@testable import SemanticVersioning
+
+final class SemanticVersionComparableTests: XCTestCase {
+    
+    func testCoreMajorComparison() throws {
+        let left = SemanticVersion(major: 1, minor: 0, patch: 0)
+        let right = SemanticVersion(major: 2, minor: 0, patch: 0)
+        
+        XCTAssertLessThan(left, right)
+        XCTAssertGreaterThan(right, left)
+        XCTAssertNotEqual(left, right)
+    }
+    
+    func testCoreMinorComparison() throws {
+        let left = SemanticVersion(major: 1, minor: 1, patch: 0)
+        let right = SemanticVersion(major: 1, minor: 2, patch: 0)
+        
+        XCTAssertLessThan(left, right)
+        XCTAssertGreaterThan(right, left)
+        XCTAssertNotEqual(left, right)
+    }
+    
+    func testCorePatchComparison() throws {
+        let left = SemanticVersion(major: 1, minor: 0, patch: 1)
+        let right = SemanticVersion(major: 1, minor: 0, patch: 2)
+        
+        XCTAssertLessThan(left, right)
+        XCTAssertGreaterThan(right, left)
+        XCTAssertNotEqual(left, right)
+    }
+    
+    func testCoreReleaseIdentifiers1() throws {
+        let left = SemanticVersion(major: 1, minor: 0, patch: 0, preReleaseIdentifiers: ["alpha"])
+        let right = SemanticVersion(major: 1, minor: 0, patch: 0)
+        
+        XCTAssertLessThan(left, right)
+        XCTAssertGreaterThan(right, left)
+        XCTAssertNotEqual(left, right)
+    }
+    
+    func testCoreReleaseIdentifiers2() throws {
+        let left = SemanticVersion(major: 1, minor: 0, patch: 0, preReleaseIdentifiers: ["alpha"])
+        let right = SemanticVersion(major: 1, minor: 0, patch: 0, preReleaseIdentifiers: ["alpha", "1"])
+        
+        XCTAssertLessThan(left, right)
+        XCTAssertGreaterThan(right, left)
+        XCTAssertNotEqual(left, right)
+    }
+    
+    func testCoreReleaseIdentifiers3() throws {
+        let left = SemanticVersion(major: 1, minor: 0, patch: 0, preReleaseIdentifiers: ["alpha", "1"])
+        let right = SemanticVersion(major: 1, minor: 0, patch: 0, preReleaseIdentifiers: ["alpha", "2"])
+        
+        XCTAssertLessThan(left, right)
+        XCTAssertGreaterThan(right, left)
+        XCTAssertNotEqual(left, right)
+    }
+
+    static var allTests = [
+        ("testCoreMajorComparison", testCoreMajorComparison),
+        ("testCoreMinorComparison", testCoreMinorComparison),
+        ("testCorePatchComparison", testCorePatchComparison),
+        ("testCoreReleaseIdentifiers1", testCoreReleaseIdentifiers1),
+        ("testCoreReleaseIdentifiers2", testCoreReleaseIdentifiers2),
+        ("testCoreReleaseIdentifiers3", testCoreReleaseIdentifiers3)
+    ]
+}
+

--- a/Targets/SemanticVersioning/Tests/SemanticVersionTests.swift
+++ b/Targets/SemanticVersioning/Tests/SemanticVersionTests.swift
@@ -1,0 +1,165 @@
+//
+//  SemanticVersionTests.swift
+//  
+//
+//  Created by Alexander Weiß on 21.11.20.
+//
+
+import Foundation
+import XCTest
+@testable import SemanticVersioning
+import ParserCombinator
+
+final class SemanticVersionTests: XCTestCase {
+    
+    func testCore() throws {
+        let semverString = "1.0.0"
+
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+    }
+    
+    
+    func testPreReleaseIdentifiers1() throws {
+        let semverString = "1.0.0-alpha"
+        
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        
+        XCTAssertEqual(version.buildIdentifiers.count, 0)
+        
+        XCTAssertEqual(version.preReleaseIdentifiers.count, 1)
+        XCTAssertEqual(version.preReleaseIdentifiers[0], "alpha")
+    }
+    
+    func testPreReleaseIdentifiers2() throws {
+        let semverString = "1.0.0-alpha.1"
+
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        
+        XCTAssertEqual(version.buildIdentifiers.count, 0)
+        
+        XCTAssertEqual(version.preReleaseIdentifiers.count, 2)
+        XCTAssertEqual(version.preReleaseIdentifiers[0], "alpha")
+        XCTAssertEqual(version.preReleaseIdentifiers[1], "1")
+    }
+    
+    func testPreReleaseIdentifiers3() throws {
+        let semverString = "1.0.0-x.7.z.92"
+
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        
+        XCTAssertEqual(version.buildIdentifiers.count, 0)
+        
+        XCTAssertEqual(version.preReleaseIdentifiers.count, 4)
+        XCTAssertEqual(version.preReleaseIdentifiers[0], "x")
+        XCTAssertEqual(version.preReleaseIdentifiers[1], "7")
+        XCTAssertEqual(version.preReleaseIdentifiers[2], "z")
+        XCTAssertEqual(version.preReleaseIdentifiers[3], "92")
+    }
+    
+    func testPreReleaseIdentifiers4() throws {
+        let semverString = "1.0.0-x-y-z.-"
+
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        
+        XCTAssertEqual(version.buildIdentifiers.count, 0)
+        
+        XCTAssertEqual(version.preReleaseIdentifiers.count, 2)
+        XCTAssertEqual(version.preReleaseIdentifiers[0], "x-y-z")
+        XCTAssertEqual(version.preReleaseIdentifiers[1], "-")
+    }
+    
+    func testBuildIdentifiers1() throws {
+        let semverString = "1.0.0+20130313144700"
+
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        
+        XCTAssertEqual(version.preReleaseIdentifiers.count, 0)
+        
+        XCTAssertEqual(version.buildIdentifiers.count, 1)
+        XCTAssertEqual(version.buildIdentifiers[0], "20130313144700")
+    }
+    
+    func testBuildIdentifiers2() throws {
+        let semverString = "1.0.0+exp.sha.5114f85"
+
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        
+        XCTAssertEqual(version.preReleaseIdentifiers.count, 0)
+        
+        XCTAssertEqual(version.buildIdentifiers.count, 3)
+        XCTAssertEqual(version.buildIdentifiers[0], "exp")
+        XCTAssertEqual(version.buildIdentifiers[1], "sha")
+        XCTAssertEqual(version.buildIdentifiers[2], "5114f85")
+    }
+    
+    func testBuildIdentifiers3() throws {
+        let semverString = "1.0.0+21AF26D3--117B344092BD"
+
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        
+        XCTAssertEqual(version.preReleaseIdentifiers.count, 0)
+        
+        XCTAssertEqual(version.buildIdentifiers.count, 1)
+        XCTAssertEqual(version.buildIdentifiers[0], "21AF26D3--117B344092BD")
+    }
+    
+    func testPreAndBuildIdentifiers() throws {
+        let semverString = "1.0.0-alpha+001"
+
+        let version = try XCTUnwrap(SemanticVersion(data: semverString))
+        
+        XCTAssertEqual(version.major, 1)
+        XCTAssertEqual(version.minor, 0)
+        XCTAssertEqual(version.patch, 0)
+        
+        XCTAssertEqual(version.preReleaseIdentifiers.count, 1)
+        XCTAssertEqual(version.preReleaseIdentifiers[0], "alpha")
+        
+        XCTAssertEqual(version.buildIdentifiers.count, 1)
+        XCTAssertEqual(version.buildIdentifiers[0], "001")
+    }
+    
+    static var allTests = [
+        ("testCore", testCore),
+        ("testPreReleaseIdentifiers1", testPreReleaseIdentifiers1),
+        ("testPreReleaseIdentifiers2", testPreReleaseIdentifiers2),
+        ("testPreReleaseIdentifiers3", testPreReleaseIdentifiers3),
+        ("testPreReleaseIdentifiers4", testPreReleaseIdentifiers4),
+        ("testBuildIdentifiers1", testBuildIdentifiers1),
+        ("testBuildIdentifiers2", testBuildIdentifiers2),
+        ("testBuildIdentifiers3", testBuildIdentifiers3),
+        ("testPreAndBuildIdentifiers", testPreAndBuildIdentifiers)
+    ]
+}


### PR DESCRIPTION
This PR implements the grouping of traversed commits by their tag into a meaningful data structure called `Changelog`. 

A `Changelog` is divided into a set of `ChangeSet` where each `ChangeSet` consists of a `Version` and a set of `Changes`. A `Change` consists of a `Commit` and if also the `ConventionalCommit` representation of the commits message. 